### PR TITLE
Added padding between "View the solution" and "Skip this move"

### DIFF
--- a/ui/analyse/css/_retro.scss
+++ b/ui/analyse/css/_retro.scss
@@ -48,4 +48,9 @@
     font-size: 2.5em;
     margin-inline-end: 10px;
   }
+  
+  .choices > a {
+    padding-bottom: 0.4em;
+  }
+
 }


### PR DESCRIPTION
Added padding between "View the solution" and "Skip this move" in the game retro section.

In the analysis/retro section, the links for "View the solution" and "Skip this move" are too close so users end up clicking "Skip this move" instead of "View the solution".